### PR TITLE
Fix issue where gradle build output is lost

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: java
 script: mvn integration-test
 jdk:
-  - oraclejdk6
+  - oraclejdk8
   - oraclejdk7
   - openjdk7
 

--- a/pom.xml
+++ b/pom.xml
@@ -73,6 +73,13 @@
 		</plugins>
 	</build>
 	<dependencies>
+	    <!-- dependencies to annotations -->
+	    <dependency>
+	      <groupId>org.apache.maven.plugin-tools</groupId>
+	      <artifactId>maven-plugin-annotations</artifactId>
+	      <version>3.0</version>
+	      <scope>provided</scope><!-- annotations are needed only to build the plugin -->
+	    </dependency>
 		<dependency>
 			<groupId>org.apache.maven</groupId>
 			<artifactId>maven-plugin-api</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -54,6 +54,11 @@
 						<pomInclude>**/pom.xml</pomInclude>
 					</pomIncludes>
 					<postBuildHookScript>verify</postBuildHookScript>
+					<!-- need to stream logs since when running
+						in travis-ci, we can't easily get access
+						to build.log
+					-->
+					<streamLogs>true</streamLogs>
 				</configuration>
 				<executions>
 					<execution>

--- a/src/main/java/org/fortasoft/maven/plugin/gradle/GradleMojo.java
+++ b/src/main/java/org/fortasoft/maven/plugin/gradle/GradleMojo.java
@@ -243,6 +243,12 @@ public class GradleMojo extends AbstractMojo {
 			BuildLauncher launcher = connection.newBuild();
 			launcher.forTasks(getTasks());
 
+			// Make sure to setStandardOut & Error otherwise
+			// basic gradle build output will be lost
+			// making troubleshooting hard
+            launcher.setStandardOutput(System.out);
+            launcher.setStandardError(System.err);
+
 			if (jvmArgs != null && jvmArgs.length > 0) {
 				launcher.setJvmArguments(jvmArgs);
 			}

--- a/src/main/java/org/fortasoft/maven/plugin/gradle/GradleMojo.java
+++ b/src/main/java/org/fortasoft/maven/plugin/gradle/GradleMojo.java
@@ -36,84 +36,59 @@ import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
 
+import org.apache.maven.plugins.annotations.Parameter;
+import org.apache.maven.plugins.annotations.Mojo;
+
 /**
  * Goal which invokes gradle!
  * 
- * @goal invoke
- * 
  */
+@Mojo(name="invoke")
 public class GradleMojo extends AbstractMojo {
 
-	/**
-	 * @parameter expression="1.7"
-	 * @required
-	 */
+	@Parameter(defaultValue="1.7", required=true)
 	private String gradleVersion;
 
-	/**
-	 * @parameter expression="${tasks}"
-	 */
+
+	@Parameter(defaultValue="${tasks}")
 	private String[] tasks;
 
-	/**
-	 * @parameter expression="${task}"
-	 */
+
+	@Parameter(defaultValue="${task}")
 	private String task;
 
-	/**
-	 * @parameter expression="${project.basedir}"
-	 */
+
+	@Parameter(defaultValue="${project.basedir}")
 	private File gradleProjectDirectory;
 
-	/**
-	 * @parameter
-	 * 
-	 */
+	@Parameter
 	private String checkInvokeScript;
 
-	/**
-	 * 
-	 * @parameter
-	 */
+	@Parameter
 	private String[] args;
 
-	/**
-	 * 
-	 * @parameter
-	 */
+	@Parameter
 	private String[] jvmArgs;
 
-	/**
-	 * @parameter
-	 */
+	@Parameter
 	private File javaHome;
 
-	/**
-	 * 
-	 * @parameter expression="${project.basedir}"
-	 * @required
-	 */
+
+	@Parameter(defaultValue="${project.basedir}",
+		required=true)
 	private File mavenBaseDir;
 	
 	
-	/**
-	 * @parameter
-	 */
 	// http://www.gradle.org/docs/current/javadoc/org/gradle/tooling/GradleConnector.html#useDistribution(java.net.URI)
-
+	@Parameter
 	private String gradleDistribution;
 
-	/**
-	 * @parameter
-	 */
 	// http://www.gradle.org/docs/current/javadoc/org/gradle/tooling/GradleConnector.html#useGradleUserHomeDir(java.io.File)
+	@Parameter
 	private File gradleUserHomeDir;
 
-	/**
-	 * @parameter
-	 */
 	// http://www.gradle.org/docs/current/javadoc/org/gradle/tooling/GradleConnector.html#useInstallation(java.io.File)
-
+	@Parameter
 	private File gradleInstallationDir;
 	
 


### PR DESCRIPTION
You're plugin is just what I need.  One problem I'm running into however is that any output coming from my gradle build that is invoked via your plugin is that any build output gets lost -- for example, if there are any println statements in the build (or coming from plugins references from the build.gradle file.

It seems the fix to this is to simply wire up stderr and stdout to the tooling launcher prior to running.   I build this locally and confirmed it's working for me.  I'm hoping you can pick this up so I don't have to maintain a separate fork.

I'm fairly new to pull requests and forks.  I hope I'm doing this right.  Thanks.

Doug
