### PR TITLE
Allow specification of a file rather than an URI for local Gradle installation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,21 @@
-target
+# Eclipse
 .classpath
-.settings
 .project
+.settings/
+
+# Intellij
+.idea/
+*.iml
+*.iws
+
+# Mac
+.DS_Store
+
+# Maven
+log/
+target/
+site/
+
+# Gradle
 .gradle/
-build/
-output.txt
-.metadata
+

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ To use the plugin, simply declare the plugin and bind it to the maven lifecycle 
 	<plugin>
 		<groupId>org.fortasoft</groupId>
 		<artifactId>gradle-maven-plugin</artifactId>
-		<version>1.0.5</version>
+		<version>1.0.7</version>
 		<configuration>
 			<tasks>
 				<!-- this would effectively call "gradle doSomething" -->

--- a/README.md
+++ b/README.md
@@ -1,10 +1,8 @@
+This is fork of **LendingClub/gradle-maven-plugin** with basic maintenance.
+
 # gradle-maven-plugin
 
-[![Circle CI](https://circleci.com/gh/LendingClub/gradle-maven-plugin.svg?style=svg)](https://circleci.com/gh/LendingClub/gradle-maven-plugin)
-
-
 This is a maven plugin that makes it easy to invoke Gradle tasks from within Maven.  
-
 
 # Objective
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ To use the plugin, simply declare the plugin and bind it to the maven lifecycle 
 	<plugin>
 		<groupId>org.fortasoft</groupId>
 		<artifactId>gradle-maven-plugin</artifactId>
-		<version>1.0.7</version>
+		<version>1.0.8</version>
 		<configuration>
 			<tasks>
 				<!-- this would effectively call "gradle doSomething" -->

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <groupId>codes.rafael.gradlemavenplugin</groupId>
     <artifactId>gradle-maven-plugin</artifactId>
     <packaging>maven-plugin</packaging>
-    <version>1.0.10-SNAPSHOT</version>
+    <version>1.0.10</version>
     <name>gradle-maven-plugin Maven Mojo</name>
     <url>https://github.com/LendingClub/gradle-maven-plugin</url>
     <parent>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <groupId>codes.rafael.gradlemavenplugin</groupId>
     <artifactId>gradle-maven-plugin</artifactId>
     <packaging>maven-plugin</packaging>
-    <version>1.0.11-SNAPSHOT</version>
+    <version>1.0.12-SNAPSHOT</version>
     <name>gradle-maven-plugin Maven Mojo</name>
     <url>https://github.com/LendingClub/gradle-maven-plugin</url>
     <parent>
@@ -38,10 +38,12 @@
     </developers>
     <build>
         <plugins>
+
+
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-plugin-plugin</artifactId>
-                <version>3.3</version>
+                <version>3.6.0</version>
                 <configuration>
                     <skipErrorNoDescriptorsFound>true</skipErrorNoDescriptorsFound>
                 </configuration>
@@ -58,6 +60,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-source-plugin</artifactId>
+                <version>3.0.1</version>
                 <executions>
                     <execution>
                         <id>attach-sources</id>
@@ -69,16 +72,16 @@
             </plugin>
             <plugin>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>2.5.1</version>
+                <version>3.8.0</version>
                 <configuration>
-                    <source>1.7</source>
-                    <target>1.7</target>
+                    <source>1.8</source>
+                    <target>1.8</target>
                 </configuration>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-invoker-plugin</artifactId>
-                <version>1.8</version>
+                <version>3.2.0</version>
                 <configuration>
                     <debug>false</debug>
                     <cloneProjectsTo>${project.build.directory}/it</cloneProjectsTo>
@@ -127,19 +130,19 @@
         <dependency>
             <groupId>org.apache.maven.plugin-tools</groupId>
             <artifactId>maven-plugin-annotations</artifactId>
-            <version>3.4</version>
+            <version>3.6.0</version>
             <scope>provided</scope>
             <!-- annotations are needed only to build the plugin -->
         </dependency>
         <dependency>
             <groupId>org.apache.maven</groupId>
             <artifactId>maven-plugin-api</artifactId>
-            <version>3.3.9</version>
+            <version>3.6.0</version>
         </dependency>
         <dependency>
             <groupId>org.apache.maven</groupId>
             <artifactId>maven-core</artifactId>
-            <version>3.3.9</version>
+            <version>3.6.0</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>
@@ -150,7 +153,7 @@
         <dependency>
             <groupId>org.gradle</groupId>
             <artifactId>gradle-tooling-api</artifactId>
-            <version>4.5</version>
+            <version>5.2.1</version>
         </dependency>
         <dependency>
             <groupId>junit</groupId>
@@ -161,7 +164,8 @@
         <dependency>
             <groupId>org.codehaus.groovy</groupId>
             <artifactId>groovy-all</artifactId>
-            <version>2.0.6</version>
+            <version>2.5.6</version>
+            <type>pom</type>
         </dependency>
     </dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -168,7 +168,7 @@
     <repositories>
         <repository>
             <id>gradle</id>
-            <url>http://repo.gradle.org/gradle/libs-releases-local/</url>
+            <url>https://repo.gradle.org/gradle/libs-releases-local/</url>
         </repository>
     </repositories>
 

--- a/pom.xml
+++ b/pom.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
-    <groupId>org.fortasoft</groupId>
+    <groupId>codes.rafael.gradlemavenplugin</groupId>
     <artifactId>gradle-maven-plugin</artifactId>
     <packaging>maven-plugin</packaging>
-    <version>1.0.8</version>
+    <version>1.0.0-SNAPSHOT</version>
     <name>gradle-maven-plugin Maven Mojo</name>
     <url>https://github.com/LendingClub/gradle-maven-plugin</url>
     <parent>
@@ -20,15 +20,20 @@
         </license>
     </licenses>
     <scm>
-        <connection>scm:git:git@github.com:LendingClub/gradle-maven-plugin.git</connection>
-        <developerConnection>scm:git:git@github.com:LendingClub/gradle-maven-plugin.git</developerConnection>
-        <url>git@github.com:LendingClub/gradle-maven-plugin.git</url>
+        <connection>scm:git:git@github.com:raphw/gradle-maven-plugin.git</connection>
+        <developerConnection>scm:git:git@github.com:raphw/gradle-maven-plugin.git</developerConnection>
+        <url>git@github.com:raphw/gradle-maven-plugin.git</url>
     </scm>
     <developers>
         <developer>
             <id>rob</id>
             <name>Rob Schoening</name>
             <email>robschoening@gmail.com</email>
+        </developer>
+        <developer>
+            <id>raphw</id>
+            <name>Rafael Winterhalter</name>
+            <email>rafael.wth@gmail.com</email>
         </developer>
     </developers>
     <build>
@@ -150,7 +155,7 @@
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <version>4.11</version>
+            <version>4.12</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -159,16 +164,18 @@
             <version>2.0.6</version>
         </dependency>
     </dependencies>
+
     <repositories>
         <repository>
             <id>gradle</id>
             <url>http://repo.gradle.org/gradle/libs-releases-local/</url>
         </repository>
     </repositories>
+
     <distributionManagement>
         <repository>
             <id>bintray</id>
-            <url>https://api.bintray.com/maven/robschoening/gradle-maven-plugin/gradle-maven-plugin</url>
+            <url>https://api.bintray.com/maven/raphw/maven/gradle-maven-plugin</url>
         </repository>
     </distributionManagement>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <groupId>codes.rafael.gradlemavenplugin</groupId>
     <artifactId>gradle-maven-plugin</artifactId>
     <packaging>maven-plugin</packaging>
-    <version>1.0.10</version>
+    <version>1.0.11-SNAPSHOT</version>
     <name>gradle-maven-plugin Maven Mojo</name>
     <url>https://github.com/LendingClub/gradle-maven-plugin</url>
     <parent>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <groupId>codes.rafael.gradlemavenplugin</groupId>
     <artifactId>gradle-maven-plugin</artifactId>
     <packaging>maven-plugin</packaging>
-    <version>1.0.0-SNAPSHOT</version>
+    <version>1.0.9</version>
     <name>gradle-maven-plugin Maven Mojo</name>
     <url>https://github.com/LendingClub/gradle-maven-plugin</url>
     <parent>

--- a/pom.xml
+++ b/pom.xml
@@ -4,9 +4,9 @@
     <groupId>org.fortasoft</groupId>
     <artifactId>gradle-maven-plugin</artifactId>
     <packaging>maven-plugin</packaging>
-    <version>1.0.7</version>
+    <version>1.0.8</version>
     <name>gradle-maven-plugin Maven Mojo</name>
-    <url>https://github.com/if6was9/gradle-maven-plugin</url>
+    <url>https://github.com/LendingClub/gradle-maven-plugin</url>
     <parent>
         <groupId>org.sonatype.oss</groupId>
         <artifactId>oss-parent</artifactId>
@@ -20,9 +20,9 @@
         </license>
     </licenses>
     <scm>
-        <connection>scm:git:git@github.com:if6was9/gradle-maven-plugin.git</connection>
-        <developerConnection>scm:git:git@github.com:if6was9/gradle-maven-plugin.git</developerConnection>
-        <url>git@github.com:if6was9/gradle-maven-plugin.git</url>
+        <connection>scm:git:git@github.com:LendingClub/gradle-maven-plugin.git</connection>
+        <developerConnection>scm:git:git@github.com:LendingClub/gradle-maven-plugin.git</developerConnection>
+        <url>git@github.com:LendingClub/gradle-maven-plugin.git</url>
     </scm>
     <developers>
         <developer>
@@ -122,19 +122,19 @@
         <dependency>
             <groupId>org.apache.maven.plugin-tools</groupId>
             <artifactId>maven-plugin-annotations</artifactId>
-            <version>3.0</version>
+            <version>3.4</version>
             <scope>provided</scope>
             <!-- annotations are needed only to build the plugin -->
         </dependency>
         <dependency>
             <groupId>org.apache.maven</groupId>
             <artifactId>maven-plugin-api</artifactId>
-            <version>2.0</version>
+            <version>3.3.9</version>
         </dependency>
         <dependency>
             <groupId>org.apache.maven</groupId>
             <artifactId>maven-core</artifactId>
-            <version>3.0</version>
+            <version>3.3.9</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>
@@ -145,7 +145,7 @@
         <dependency>
             <groupId>org.gradle</groupId>
             <artifactId>gradle-tooling-api</artifactId>
-            <version>1.7</version>
+            <version>2.13</version>
         </dependency>
         <dependency>
             <groupId>junit</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <groupId>codes.rafael.gradlemavenplugin</groupId>
     <artifactId>gradle-maven-plugin</artifactId>
     <packaging>maven-plugin</packaging>
-    <version>1.0.9</version>
+    <version>1.0.10-SNAPSHOT</version>
     <name>gradle-maven-plugin Maven Mojo</name>
     <url>https://github.com/LendingClub/gradle-maven-plugin</url>
     <parent>

--- a/pom.xml
+++ b/pom.xml
@@ -71,8 +71,8 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>2.5.1</version>
                 <configuration>
-                    <source>1.6</source>
-                    <target>1.6</target>
+                    <source>1.7</source>
+                    <target>1.7</target>
                 </configuration>
             </plugin>
             <plugin>
@@ -150,7 +150,7 @@
         <dependency>
             <groupId>org.gradle</groupId>
             <artifactId>gradle-tooling-api</artifactId>
-            <version>2.13</version>
+            <version>4.5</version>
         </dependency>
         <dependency>
             <groupId>junit</groupId>

--- a/src/it/check-invoke-it/pom.xml
+++ b/src/it/check-invoke-it/pom.xml
@@ -11,16 +11,16 @@
 <plugins>
 	<plugin>
 		<artifactId>maven-compiler-plugin</artifactId>
-		<version>3.0</version>
+		<version>3.8.0</version>
 		<configuration>
-			<source>1.6</source>
-			<target>1.6</target>
+			<source>1.8</source>
+			<target>1.8</target>
 		</configuration>
 	</plugin>
 	<plugin>
-	       <groupId>org.fortasoft</groupId>
-	      <artifactId>gradle-maven-plugin</artifactId>
-	      <version>1.0.8</version>
+		<groupId>codes.rafael.gradlemavenplugin</groupId>
+		<artifactId>gradle-maven-plugin</artifactId>
+		<version>1.0.12-SNAPSHOT</version>
 	        <configuration>
 	        	<tasks>
 					<task>doIt</task>

--- a/src/it/check-invoke-it/pom.xml
+++ b/src/it/check-invoke-it/pom.xml
@@ -4,7 +4,7 @@
   <groupId>org.fortasoft.test</groupId>
   <artifactId>check-invoke-it</artifactId>
   <packaging>jar</packaging>
-  <version>1.0.7</version>
+  <version>1.0.8</version>
   <name>gradle-maven-plugin Maven Mojo</name>
   <url>http://maven.apache.org</url>
 <build>
@@ -20,7 +20,7 @@
 	<plugin>
 	       <groupId>org.fortasoft</groupId>
 	      <artifactId>gradle-maven-plugin</artifactId>
-	      <version>1.0.7</version>
+	      <version>1.0.8</version>
 	        <configuration>
 	        	<tasks>
 					<task>doIt</task>

--- a/src/it/main-it/build.gradle
+++ b/src/it/main-it/build.gradle
@@ -2,13 +2,17 @@ apply plugin: 'maven'
 apply plugin: 'java'
 
 
-clean.doLast {
-	File f = new File("build/classes/main/test/TestBean.class");
-	if (f.exists()) {
-		throw new GradleException("compiled TestBean should be gone");
+clean{
+	doLast {
+		File f = new File("build/classes/main/test/TestBean.class");
+		if (f.exists()) {
+			throw new GradleException("compiled TestBean should be gone");
+		}
 	}
 }
-task writeFile << {
-	File f = new File(rootDir,"build/output.txt");
-	f.setText("hello");
+task writeFile {
+	doLast {
+		File f = new File(rootDir, "build/output.txt");
+		f.setText("hello");
+	}
 }

--- a/src/it/main-it/pom.xml
+++ b/src/it/main-it/pom.xml
@@ -4,7 +4,7 @@
   <groupId>org.fortasoft.test</groupId>
   <artifactId>gradle-maven-plugin-test</artifactId>
   <packaging>jar</packaging>
-  <version>1.0.7</version>
+  <version>1.0.8</version>
   <name>gradle-maven-plugin Maven Mojo</name>
   <url>http://maven.apache.org</url>
 <build>
@@ -20,7 +20,7 @@
 	<plugin>
 	       <groupId>org.fortasoft</groupId>
 	      <artifactId>gradle-maven-plugin</artifactId>
-	      <version>1.0.7</version>
+	      <version>1.0.8</version>
 	        <configuration>
 	        	<tasks>
 					<task>clean</task>

--- a/src/it/main-it/pom.xml
+++ b/src/it/main-it/pom.xml
@@ -1,57 +1,57 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
-  <modelVersion>4.0.0</modelVersion>
-  <groupId>org.fortasoft.test</groupId>
-  <artifactId>gradle-maven-plugin-test</artifactId>
-  <packaging>jar</packaging>
-  <version>1.0.8</version>
-  <name>gradle-maven-plugin Maven Mojo</name>
-  <url>http://maven.apache.org</url>
-<build>
-<plugins>
-	<plugin>
-		<artifactId>maven-compiler-plugin</artifactId>
-		<version>3.0</version>
-		<configuration>
-			<source>1.6</source>
-			<target>1.6</target>
-		</configuration>
-	</plugin>
-	<plugin>
-	       <groupId>org.fortasoft</groupId>
-	      <artifactId>gradle-maven-plugin</artifactId>
-	      <version>1.0.8</version>
-	        <configuration>
-	        	<tasks>
-					<task>clean</task>
-						<task>compileJava</task>
-						<task>writeFile</task>
-				</tasks>
-				<!--
-				<gradleProjectDirectory>${project.basedir}</gradleProjectDirectory>
-				<args>
-					<arg>-q</arg>
-				</args>
-				<jvmArgs>
-					<jvmArg>-XX:MaxPermSize=128m</jvmArg>
-				</jvmArgs>
-			    <javaHome>/System/Library/Java/JavaVirtualMachines/1.6.0.jdk/Contents/Home</javaHome>
-				-->
-	       </configuration>
-	        <executions>
-	          <execution>
-	            <phase>compile</phase>
-	            <goals>
-	              <goal>invoke</goal>
-	            </goals>
-	          </execution>
-	        </executions>
-	      </plugin>
-</plugins>
-</build>
-  <dependencies>
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>codes.rafael.gradlemavenplugin</groupId>
+    <artifactId>gradle-maven-plugin-test</artifactId>
+    <packaging>jar</packaging>
+    <version>1.0.12-SNAPSHOT</version>
+    <name>gradle-maven-plugin Maven Mojo</name>
+    <url>http://maven.apache.org</url>
+    <build>
+        <plugins>
+            <plugin>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.8.0</version>
+                <configuration>
+                    <source>1.8</source>
+                    <target>1.8</target>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>codes.rafael.gradlemavenplugin</groupId>
+                <artifactId>gradle-maven-plugin</artifactId>
+                <version>1.0.12-SNAPSHOT</version>
+                <configuration>
+                    <tasks>
+                        <task>clean</task>
+                        <task>compileJava</task>
+                        <task>writeFile</task>
+                    </tasks>
+                    <!--
+                    <gradleProjectDirectory>${project.basedir}</gradleProjectDirectory>
+                    <args>
+                        <arg>-q</arg>
+                    </args>
+                    <jvmArgs>
+                        <jvmArg>-XX:MaxPermSize=128m</jvmArg>
+                    </jvmArgs>
+                    <javaHome>/System/Library/Java/JavaVirtualMachines/1.6.0.jdk/Contents/Home</javaHome>
+                    -->
+                </configuration>
+                <executions>
+                    <execution>
+                        <phase>compile</phase>
+                        <goals>
+                            <goal>invoke</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+    <dependencies>
 
-   
-  </dependencies>
+
+    </dependencies>
 
 </project>

--- a/src/main/java/org/fortasoft/maven/plugin/gradle/GradleMojo.java
+++ b/src/main/java/org/fortasoft/maven/plugin/gradle/GradleMojo.java
@@ -65,7 +65,7 @@ public class GradleMojo extends AbstractMojo {
 	*/
 	public static final String SYS_PREFIX = "gradle.sys.";
 
-	@Parameter(defaultValue="2.13", required=true)
+	@Parameter(defaultValue="5.2.1", required=true)
 	private String gradleVersion;
 
 

--- a/src/main/java/org/fortasoft/maven/plugin/gradle/GradleMojo.java
+++ b/src/main/java/org/fortasoft/maven/plugin/gradle/GradleMojo.java
@@ -101,6 +101,10 @@ public class GradleMojo extends AbstractMojo {
 	@Parameter
 	private String gradleDistribution;
 
+	// http://www.gradle.org/docs/current/javadoc/org/gradle/tooling/GradleConnector.html#useDistribution(java.net.URI)
+	@Parameter
+	private String gradleDistributionFile;
+
 	// http://www.gradle.org/docs/current/javadoc/org/gradle/tooling/GradleConnector.html#useGradleUserHomeDir(java.io.File)
 	@Parameter
 	private File gradleUserHomeDir;
@@ -230,6 +234,9 @@ public class GradleMojo extends AbstractMojo {
 			if (gradleDistribution != null) {
 				getLog().info("gradleDistributionUri: " + gradleDistribution);
 				c = c.useDistribution(new URI(gradleDistribution));
+			} else if (gradleDistributionFile != null) {
+				getLog().info("gradleDistributionFile: " + gradleDistributionFile);
+				c = c.useDistribution(new File(gradleDistributionFile).toURI());
 			}
 
 			connection = c.connect();

--- a/src/main/java/org/fortasoft/maven/plugin/gradle/GradleMojo.java
+++ b/src/main/java/org/fortasoft/maven/plugin/gradle/GradleMojo.java
@@ -65,7 +65,7 @@ public class GradleMojo extends AbstractMojo {
 	*/
 	public static final String SYS_PREFIX = "gradle.sys.";
 
-	@Parameter(defaultValue="2.4", required=true)
+	@Parameter(defaultValue="2.13", required=true)
 	private String gradleVersion;
 
 

--- a/src/main/java/org/fortasoft/maven/plugin/gradle/GradleMojo.java
+++ b/src/main/java/org/fortasoft/maven/plugin/gradle/GradleMojo.java
@@ -186,8 +186,7 @@ public class GradleMojo extends AbstractMojo {
 			Object rval = gs.evaluate(checkInvokeScript);
 
 			if (rval != null && rval instanceof Boolean) {
-				Boolean boolRval = (Boolean) rval;
-				shouldExecute = boolRval.booleanValue();
+				shouldExecute = (Boolean) rval;
 			} else {
 				throw new MojoFailureException(
 						"checkScript must return boolean");
@@ -208,7 +207,7 @@ public class GradleMojo extends AbstractMojo {
 			}
 
 			GradleConnector c = GradleConnector.newConnector();
-			getLog().info("jvmArgs: " + args);
+			getLog().info("jvmArgs: " + Arrays.toString(args));
 			getLog().info(
 					"gradleProjectDirectory: "
 							+ getGradleProjectDirectory().getAbsolutePath());
@@ -250,7 +249,7 @@ public class GradleMojo extends AbstractMojo {
 
 			String[] finalArgs = buildFinalArgs(args);
 
-			if (finalArgs != null && finalArgs.length > 0) {
+			if (finalArgs.length > 0) {
 				launcher.withArguments(finalArgs);
 			}
 			if (javaHome != null) {
@@ -291,9 +290,7 @@ public class GradleMojo extends AbstractMojo {
 		List<String> argList = new ArrayList<String>();
 
 		if (args != null) {
-			for (int i=0; i < args.length; i++) {
-				argList.add(args[i]);
-			}
+			argList.addAll(Arrays.asList(args));
 		}
 
 		boolean offline = session.getSettings().isOffline();

--- a/src/main/java/org/slf4j/impl/MojoLoggerFactory.java
+++ b/src/main/java/org/slf4j/impl/MojoLoggerFactory.java
@@ -31,8 +31,7 @@ import org.slf4j.Logger;
 import org.slf4j.ILoggerFactory;
 
 /**
- * An implementation of {@link ILoggerFactory} which always returns
- * {@link MojoLogger} instances.
+ * An implementation of {@link ILoggerFactory} which always returns a MojoLogger instances.
  * 
  * @author Ceki G&uuml;lc&uuml;
  */
@@ -48,7 +47,7 @@ public class MojoLoggerFactory implements ILoggerFactory {
   }
 
   /**
-   * Return an appropriate {@link MojoLogger} instance by name.
+   * Return an appropriate logger instance by name.
    */
   public Logger getLogger(String name) {
     return new NewMojoLogger();

--- a/src/main/java/org/slf4j/impl/StaticMDCBinder.java
+++ b/src/main/java/org/slf4j/impl/StaticMDCBinder.java
@@ -45,8 +45,7 @@ public class StaticMDCBinder {
   }
   
   /**
-   * Currently this method always returns an instance of 
-   * {@link StaticMDCBinder}.
+   * @return Currently this method always returns an instance of {@link StaticMDCBinder}.
    */
   public MDCAdapter getMDCA() {
      return new NOPMDCAdapter();


### PR DESCRIPTION
It is much easier to specify a file from within Maven using for example `${project.basedir}/dist/mygradle.zip` to point to a locally available distribution. Within Windows, one has to replace spaces by escape characters and invert the delimiters what is quite a hazzle. By allowing the suggested property, this can be solved much easier.

Also, I fixed a print-out of the arguments and added some minor improvements.