### PR TITLE
Gradle repository does not support insecure communication anymore.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -162,7 +162,7 @@
     <repositories>
         <repository>
             <id>gradle</id>
-            <url>http://repo.gradle.org/gradle/libs-releases-local/</url>
+            <url>https://repo.gradle.org/gradle/libs-releases-local/</url>
         </repository>
     </repositories>
     <distributionManagement>


### PR DESCRIPTION
Use https instead of http